### PR TITLE
Remove `overflow: visible` from extras.css

### DIFF
--- a/docs/css/extras.css
+++ b/docs/css/extras.css
@@ -8,7 +8,6 @@
   overflow: auto;
   font-family: monospace, monospace;
   page-break-inside: avoid;
-  overflow: visible;
   box-sizing: border-box;
   webkit-font-smoothing: antialiased;
   margin: 1em 0px 1em;


### PR DESCRIPTION
Terminal format contained both `overflow: auto` and `overflow: visible`. Because we want to see the scrollbar when content would otherwise be clipped, we should have `overflow: auto`. Reference: https://www.w3schools.com/cssref/pr_pos_overflow.asp